### PR TITLE
change the inactive titleBar bg to be the same as active

### DIFF
--- a/themes/Oceanic Next-color-theme.json
+++ b/themes/Oceanic Next-color-theme.json
@@ -306,7 +306,7 @@
     "titleBar.activeForeground": "#cde3de",
     "titleBar.activeBackground": "#1b2b34",
     "titleBar.inactiveForeground": "#b2b2b3",
-    "titleBar.inactiveBackground": "#f6f6f6",
+    "titleBar.inactiveBackground": "#1b2b34",
 
     "terminal.background": "#1b2b34",
     "terminal.foreground": "#c0c5ce",


### PR DESCRIPTION
This pull request changes the inactive titleBar bg color to be the same as the active color.  The current setting (#1b2b34) doesn't seem to have any relationship to the rest of the theme and looks really jarring when the window is inactive.  Also, for some reason on the first run of VS Code the color of the titleBar is set to inactive even if the window is active which, again, just doesn't look right.

Before the change:
![Screenshot 2019-07-03 at 10 02 41](https://user-images.githubusercontent.com/1042048/60574359-cbf5d480-9d79-11e9-9c2a-d42a9f62e4a6.png)

After the change:
![Screenshot 2019-07-03 at 10 03 11](https://user-images.githubusercontent.com/1042048/60574386-d7e19680-9d79-11e9-9e19-4c40180b1f1d.png)
